### PR TITLE
Install dependencies in release.yaml

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -43,8 +43,8 @@ jobs:
         include:
           - arch: x86_64
             runner: ubuntu-22.04
-          # - arch: aarch64
-          #   runner: ARM64-CMX
+          - arch: aarch64
+            runner: ubuntu-22.04-arm
     
     steps:
     - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,12 +45,13 @@ jobs:
         with:
           name: pktstat-bpf-x86_64
           path: ./bin
-      - name: Download aarch64 binary
-        uses: actions/download-artifact@v4
-        with:
-          name: pktstat-bpf-aarch64
-          path: ./bin
+      # - name: Download aarch64 binary
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name:pktstat-bpf-aarch64
+      #     path: ./bin
       - name: Create GitHub Release
-        run: gh release create ${{ github.ref_name }} ./bin/pktstat-bpf-x86_64 ./bin/pktstat-bpf-aarch64 --generate-notes
+        run: |
+          gh release create ${{ github.ref_name }} ./bin/pktstat-bpf-* --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang llvm libbpf-dev
       - run: make generate build VERSION=${{ github.ref_name }}
       - run: mv ./pktstat-bpf ./pktstat-bpf-x86_64
       - name: Upload x86_64 binary
@@ -32,6 +36,10 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang llvm libbpf-dev
       - run: make generate build VERSION=${{ github.ref_name }}
       - run: mv ./pktstat-bpf ./pktstat-bpf-aarch64
       - name: Upload aarch64 binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,15 @@ on:
       - "v*"
 
 jobs:
-  build-x86_64:
-    runs-on: ubuntu-22.04
+  build:
+    strategy:
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-22.04
+          # - arch: aarch64
+          #   runner: ARM64-CMX
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
       - run: git config --global --add safe.directory $(pwd) # Workaround for fatal: detected dubious ownership in repository at '/__w/reliability-matrix/reliability-matrix'
@@ -20,39 +27,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang llvm libbpf-dev
       - run: make generate build VERSION=${{ github.ref_name }}
-      - run: mv ./pktstat-bpf ./pktstat-bpf-x86_64
-      - name: Upload x86_64 binary
+      - run: mv ./pktstat-bpf ./pktstat-bpf-${{ matrix.arch }}
+      - name: Upload ${{ matrix.arch }} binary
         uses: actions/upload-artifact@v4
         with:
-          name: pktstat-bpf-x86_64
-          path: ./pktstat-bpf-x86_64
-
-  build-aarch64:
-    runs-on: ARM64-CMX
-    steps:
-      - uses: actions/checkout@v4
-      - run: git config --global --add safe.directory $(pwd) # Workaround for fatal: detected dubious ownership in repository at '/__w/reliability-matrix/reliability-matrix'
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version-file: go.mod
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang llvm libbpf-dev
-      - run: make generate build VERSION=${{ github.ref_name }}
-      - run: mv ./pktstat-bpf ./pktstat-bpf-aarch64
-      - name: Upload aarch64 binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: pktstat-bpf-aarch64
-          path: ./pktstat-bpf-aarch64
+          name: pktstat-bpf-${{ matrix.arch }}
+          path: ./pktstat-bpf-${{ matrix.arch }}
 
   create-release:
     runs-on: ubuntu-22.04
     needs:
-      - build-x86_64
-      - build-aarch64
+      - build
     steps:
       - uses: actions/checkout@v4
       - name: Download x86_64 binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,8 @@ jobs:
         include:
           - arch: x86_64
             runner: ubuntu-22.04
-          # - arch: aarch64
-          #   runner: ARM64-CMX
+          - arch: aarch64
+            runner: ubuntu-22.04-arm
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
@@ -45,11 +45,11 @@ jobs:
         with:
           name: pktstat-bpf-x86_64
           path: ./bin
-      # - name: Download aarch64 binary
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name:pktstat-bpf-aarch64
-      #     path: ./bin
+      - name: Download aarch64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: pktstat-bpf-aarch64
+          path: ./bin
       - name: Create GitHub Release
         run: |
           gh release create ${{ github.ref_name }} ./bin/pktstat-bpf-* --generate-notes

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Variables
 TARGET := pktstat-bpf
-GIT_LAST_TAG := $(shell git describe --abbrev=0 --tags 2>/dev/null || echo latest)
+VERSION ?= $(shell git describe --abbrev=0 --tags 2>/dev/null || echo latest)
 GIT_HEAD_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
-GIT_TAG_COMMIT := $(shell git rev-parse --short $(GIT_LAST_TAG) 2>/dev/null || echo unknown)
+GIT_TAG_COMMIT := $(shell git rev-parse --short $(VERSION) 2>/dev/null || echo unknown)
 GIT_MODIFIED1 := $(shell git diff $(GIT_HEAD_COMMIT) $(GIT_TAG_COMMIT) --quiet 2>/dev/null || echo .dev)
 GIT_MODIFIED2 := $(shell git diff --quiet 2>/dev/null || echo .dirty)
 GIT_MODIFIED := $(GIT_MODIFIED1)$(GIT_MODIFIED2)
@@ -18,4 +18,4 @@ generate:
 	go generate
 
 build:
-	go build -trimpath -pgo=auto -ldflags="-s -w -X main.GitTag=$(GIT_LAST_TAG) -X main.GitCommit=$(GIT_HEAD_COMMIT) -X main.GitDirty=$(GIT_MODIFIED) -X main.BuildTime=$(BUILD_DATE)" -o $(TARGET) 
+	go build -trimpath -pgo=auto -ldflags="-s -w -X main.GitTag=$(VERSION) -X main.GitCommit=$(GIT_HEAD_COMMIT) -X main.GitDirty=$(GIT_MODIFIED) -X main.BuildTime=$(BUILD_DATE)" -o $(TARGET) 


### PR DESCRIPTION
Fixing this error, but also disabling ARM builds until we have an ARM runner.

https://github.com/replicatedhq/pktstat-bpf/actions/runs/15982345686

```
Error: exec: "llvm-strip": executable file not found in $PATH
exit status 1
gen.go:24: running "go": exit status 1
make: *** [Makefile:18: generate] Error 1
```