### PR TITLE
chore(output): Filter ssh session, cluster-provisioner traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,15 @@ sudo apt install linux-headers-$(uname -r) \
                  linux-tools-common \
                  linux-tools-generic
 ```
+
+### Testing a Release with Cluster Provisioner
+Build the test release of `pktstat-bpf`:
+
+```shell
+make build
+```
+
+Move the release into the `network-report-collector-path` set in
+`/etc/cluster-provisioner/cluster-provisioner.yaml` (default: `/opt/cluster-provisioner/bin/pktstat-bpf`) and spin up a cluster
+or VM.  Cluster Provisioner will use the binary at that path to collect
+network reports.


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/126306/hide-traffic-from-cluster-provisioner-host-into-instance-within-pktstat-output

This PR fixes an issue with `pktstat` outputting a VMs SSH session traffic in addition to traffic sourced and destined to/from the cluster-provisioner host as we tail the output over SSH to batch events over to vandoor.

We now filter out this traffic so the user only ever sees events specific to their instance and only their instance.