### PR TITLE
fix: clear ebpf map after processing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.24.1
 require (
 	github.com/cilium/ebpf v0.18.0
 	github.com/goccy/go-json v0.10.5
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/peterbourgon/ff/v4 v4.0.0-alpha.4
 	k8s.io/apimachinery v0.33.1
 	k8s.io/client-go v0.33.1
@@ -24,6 +25,7 @@ require (
 	github.com/google/gnostic-models v0.6.9 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,10 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/josharian/native v1.1.0 h1:uuaP0hAbW7Y4l0ZRQ6C9zfb7Mg1mbFKry/xzDAfmtLA=

--- a/main.go
+++ b/main.go
@@ -230,12 +230,6 @@ func main() {
 					dnsLookupMapMutex.RUnlock()
 				}
 
-				// Create unique keys for tracking seen entries
-				// For regular tracking (with timestamp)
-				timeKey := fmt.Sprintf("%s:%d->%s:%d:%s:%d:%s:%s",
-					entry.SrcIP, entry.SrcPort, entry.DstIP, entry.DstPort,
-					entry.Proto, entry.Pid, entry.Comm, entry.Timestamp.Format(time.RFC3339Nano))
-
 				// For --unique tracking (without timestamp)
 				uniqueKey := fmt.Sprintf("%s:%d->%s:%d:%s:%d:%s",
 					entry.SrcIP, entry.SrcPort, entry.DstIP, entry.DstPort,
@@ -248,15 +242,11 @@ func main() {
 					// When using --unique, filter by the connection pattern without timestamp
 					if !seenEntries[uniqueKey] {
 						seenEntries[uniqueKey] = true
-						seenEntries[timeKey] = true
 						shouldInclude = true
 					}
 				} else {
-					// Normal mode, filter only exact duplicates with timestamp
-					if !seenEntries[timeKey] {
-						seenEntries[timeKey] = true
-						shouldInclude = true
-					}
+					// Normal mode, processMap will remove the last events processed, so always include events we see
+					shouldInclude = true
 				}
 
 				if shouldInclude {

--- a/output.go
+++ b/output.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	json "github.com/goccy/go-json"
+	"github.com/hashicorp/go-multierror"
 )
 
 // processMap generates statEntry objects from an ebpf.Map.
@@ -43,10 +44,12 @@ func processMap(m *ebpf.Map, sortFunc func([]statEntry)) ([]statEntry, error) {
 	)
 
 	stats := make([]statEntry, 0, m.MaxEntries())
+	observedKeys := make([]counterStatkey, 0, m.MaxEntries())
 	iter := m.Iterate()
 
 	// build statEntry slice converting data where needed
 	for iter.Next(&key, &val) {
+		observedKeys = append(observedKeys, key)
 		srcIP := bytesToAddr(key.Srcip.In6U.U6Addr8)
 		dstIP := bytesToAddr(key.Dstip.In6U.U6Addr8)
 
@@ -95,7 +98,16 @@ func processMap(m *ebpf.Map, sortFunc func([]statEntry)) ([]statEntry, error) {
 
 	sortFunc(stats)
 
-	return stats, iter.Err()
+	var result error
+	if err := iter.Err(); err != nil {
+		result = multierror.Append(result, err)
+	}
+
+	if _, err := m.BatchDelete(observedKeys, nil); err != nil {
+		result = multierror.Append(result, err)
+	}
+
+	return stats, result
 }
 
 // timeDateSort sorts a slice of statEntry objects by their Timestamp field in ascending order.


### PR DESCRIPTION
Currently the main loop does a `shouldInclude` check on each entry returned by `processMap`. This check compares some of the event's details as well as a timestamp to see if it should be printed out to stdout. However, `processMap` is setting this to `time.Now` on each call, so no event will ever satisfy the `shouldInclude` check.

This results in every event being outputted to stdout each time the main loop runs.

This change clears the bpf.PktStats map at the end of each `processMap` run. This causes only new events since the last run of `processMap` to be output to stdout.