### PR TITLE
Joshd/sc 127330/network reporting still returns data for

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ sudo apt install linux-headers-$(uname -r) \
 Build the test release of `pktstat-bpf`:
 
 ```shell
-make build
+make generate build
 ```
 
 Move the release into the `network-report-collector-path` set in


### PR DESCRIPTION
Filter out packets where
* src and dst ip are both 0.0.0.0
* dst ip is 0.0.0.0 and dst port is 0

## Test results

Running `curl www.google.com` in an ubuntu VM
```
❯ r network report --id 04b657db -w -ojson
{"created_at":"2025-08-22T15:45:55.698465Z","event_data":"{\"timestamp\":\"2025-08-22T15:45:55.698465478Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"185.125.190.57\",\"srcPort\":36582,\"dstPort\":123,\"proto\":\"TCP\",\"comm\":\"chronyd\",\"pid\":1036,\"likelyService\":\"ntp\"}\r"}
{"created_at":"2025-08-22T15:45:55.69848Z","event_data":"{\"timestamp\":\"2025-08-22T15:45:55.698480467Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"91.189.91.157\",\"srcPort\":39089,\"dstPort\":123,\"proto\":\"TCP\",\"comm\":\"chronyd\",\"pid\":1036,\"likelyService\":\"ntp\"}\r"}
{"created_at":"2025-08-22T15:45:56.698672Z","event_data":"{\"timestamp\":\"2025-08-22T15:45:56.698672937Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"185.125.190.56\",\"srcPort\":29618,\"dstPort\":123,\"proto\":\"TCP\",\"comm\":\"chronyd\",\"pid\":1036,\"likelyService\":\"ntp\"}\r"}
{"created_at":"2025-08-22T15:45:56.698688Z","event_data":"{\"timestamp\":\"2025-08-22T15:45:56.698688137Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"185.125.190.58\",\"srcPort\":65253,\"dstPort\":123,\"proto\":\"TCP\",\"comm\":\"chronyd\",\"pid\":1036,\"likelyService\":\"ntp\"}\r"}
{"created_at":"2025-08-22T15:45:57.698035Z","event_data":"{\"timestamp\":\"2025-08-22T15:45:57.698035368Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"95.216.13.213\",\"srcPort\":30358,\"dstPort\":123,\"proto\":\"TCP\",\"comm\":\"chronyd\",\"pid\":1036,\"likelyService\":\"ntp\"}\r"}
{"created_at":"2025-08-22T15:45:57.698051Z","event_data":"{\"timestamp\":\"2025-08-22T15:45:57.698051178Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"65.21.242.181\",\"srcPort\":34499,\"dstPort\":123,\"proto\":\"TCP\",\"comm\":\"chronyd\",\"pid\":1036,\"likelyService\":\"ntp\"}\r"}
{"created_at":"2025-08-22T15:45:57.69807Z","event_data":"{\"timestamp\":\"2025-08-22T15:45:57.698070706Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"37.27.215.85\",\"srcPort\":50381,\"dstPort\":123,\"proto\":\"TCP\",\"comm\":\"chronyd\",\"pid\":1036,\"likelyService\":\"ntp\"}\r"}
{"created_at":"2025-08-22T15:45:57.698093Z","event_data":"{\"timestamp\":\"2025-08-22T15:45:57.69809301Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"162.159.200.123\",\"srcPort\":51402,\"dstPort\":123,\"proto\":\"TCP\",\"comm\":\"chronyd\",\"pid\":1036,\"likelyService\":\"ntp\"}\r"}
{"created_at":"2025-08-22T15:46:30.697976Z","event_data":"{\"timestamp\":\"2025-08-22T15:46:30.697976371Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"216.58.211.228\",\"srcPort\":4824,\"dstPort\":80,\"proto\":\"TCP\",\"likelyService\":\"http\"}\r"}
{"created_at":"2025-08-22T15:46:30.698012Z","event_data":"{\"timestamp\":\"2025-08-22T15:46:30.698012531Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"216.58.211.228\",\"srcPort\":4824,\"dstPort\":80,\"proto\":\"TCP\",\"comm\":\"bash\",\"pid\":1404,\"likelyService\":\"http\"}\r"}
{"created_at":"2025-08-22T15:46:30.698019Z","event_data":"{\"timestamp\":\"2025-08-22T15:46:30.698019614Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"216.58.211.228\",\"srcPort\":4824,\"dstPort\":80,\"proto\":\"TCP\",\"comm\":\"sshd\",\"pid\":1403,\"dnsQueryName\":\"10.0.0.10\",\"likelyService\":\"http\"}\r"}
{"created_at":"2025-08-22T15:46:30.698026Z","event_data":"{\"timestamp\":\"2025-08-22T15:46:30.698026428Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"216.58.211.228\",\"srcPort\":4824,\"dstPort\":80,\"proto\":\"TCP\",\"comm\":\"curl\",\"pid\":1410,\"dnsQueryName\":\"www.google.com\",\"likelyService\":\"http\"}\r"}
```

Network reporting when creating an EC cluster:
```
❯ r network report --id 16090f6e -w -ojson
{"created_at":"2025-08-22T15:54:43.951487Z","event_data":"{\"timestamp\":\"2025-08-22T15:54:43.951487385Z\",\"srcIp\":\"10.244.101.203\",\"dstIp\":\"162.159.134.41\",\"srcPort\":7366,\"dstPort\":443,\"proto\":\"TCP\",\"comm\":\"kotsadm\",\"pid\":11190,\"sourcePod\":\"kotsadm/kotsadm-7b6c9d6b89-fpppl\",\"likelyService\":\"https\"}\r"}
{"created_at":"2025-08-22T15:54:43.957261Z","event_data":"{\"timestamp\":\"2025-08-22T15:54:43.95726115Z\",\"srcIp\":\"10.244.101.203\",\"dstIp\":\"162.159.134.41\",\"srcPort\":7366,\"dstPort\":443,\"proto\":\"TCP\",\"sourcePod\":\"kotsadm/kotsadm-7b6c9d6b89-fpppl\",\"likelyService\":\"https\"}\r"}
{"created_at":"2025-08-22T15:54:48.952625Z","event_data":"{\"timestamp\":\"2025-08-22T15:54:48.952625679Z\",\"srcIp\":\"fe80::7ccd:ccff:fea2:4822\",\"dstIp\":\"ff02::2\",\"srcPort\":133,\"dstPort\":0,\"proto\":\"IPv6-ICMP\"}\r"}
{"created_at":"2025-08-22T15:55:00.951627Z","event_data":"{\"timestamp\":\"2025-08-22T15:55:00.951627234Z\",\"srcIp\":\"fe80::4c4c:5dff:fefe:73ab\",\"dstIp\":\"ff02::2\",\"srcPort\":133,\"dstPort\":0,\"proto\":\"IPv6-ICMP\",\"comm\":\"ksoftirqd/1\",\"pid\":18}\r"}
{"created_at":"2025-08-22T15:55:06.952657Z","event_data":"{\"timestamp\":\"2025-08-22T15:55:06.952657202Z\",\"srcIp\":\"fe80::7497:adff:fe05:9369\",\"dstIp\":\"ff02::2\",\"srcPort\":133,\"dstPort\":0,\"proto\":\"IPv6-ICMP\"}\r"}
{"created_at":"2025-08-22T15:55:12.951741Z","event_data":"{\"timestamp\":\"2025-08-22T15:55:12.951741857Z\",\"srcIp\":\"fe80::9ca1:abff:fec4:6d7c\",\"dstIp\":\"ff02::2\",\"srcPort\":133,\"dstPort\":0,\"proto\":\"IPv6-ICMP\"}\r"}
{"created_at":"2025-08-22T15:55:14.952343Z","event_data":"{\"timestamp\":\"2025-08-22T15:55:14.952343755Z\",\"srcIp\":\"fe80::d4b8:feff:fee7:139f\",\"dstIp\":\"ff02::2\",\"srcPort\":133,\"dstPort\":0,\"proto\":\"IPv6-ICMP\",\"comm\":\"ksoftirqd/0\",\"pid\":12}\r"}
{"created_at":"2025-08-22T15:55:18.951285Z","event_data":"{\"timestamp\":\"2025-08-22T15:55:18.9512854Z\",\"srcIp\":\"fe80::1cb3:fff:fed8:de20\",\"dstIp\":\"ff02::2\",\"srcPort\":133,\"dstPort\":0,\"proto\":\"IPv6-ICMP\",\"comm\":\"ksoftirqd/0\",\"pid\":12}\r"}
{"created_at":"2025-08-22T15:55:22.951757Z","event_data":"{\"timestamp\":\"2025-08-22T15:55:22.951757927Z\",\"srcIp\":\"fe80::8c69:1cff:fe47:258a\",\"dstIp\":\"ff02::2\",\"srcPort\":133,\"dstPort\":0,\"proto\":\"IPv6-ICMP\"}\r"}
{"created_at":"2025-08-22T15:55:24.951485Z","event_data":"{\"timestamp\":\"2025-08-22T15:55:24.951485452Z\",\"srcIp\":\"fe80::1089:f6ff:feff:2210\",\"dstIp\":\"ff02::2\",\"srcPort\":133,\"dstPort\":0,\"proto\":\"IPv6-ICMP\",\"comm\":\"ksoftirqd/0\",\"pid\":12}\r"}
{"created_at":"2025-08-22T15:55:29.951756Z","event_data":"{\"timestamp\":\"2025-08-22T15:55:29.951756178Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"185.125.190.57\",\"srcPort\":10151,\"dstPort\":123,\"proto\":\"TCP\",\"comm\":\"chronyd\",\"pid\":911,\"sourcePod\":\"kube-system/calico-node-cl2wn\",\"likelyService\":\"ntp\"}\r"}
{"created_at":"2025-08-22T15:55:30.951282Z","event_data":"{\"timestamp\":\"2025-08-22T15:55:30.951282281Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"185.125.190.58\",\"srcPort\":61671,\"dstPort\":123,\"proto\":\"TCP\",\"comm\":\"chronyd\",\"pid\":911,\"sourcePod\":\"kube-system/calico-node-cl2wn\",\"likelyService\":\"ntp\"}\r"}
{"created_at":"2025-08-22T15:55:30.95696Z","event_data":"{\"timestamp\":\"2025-08-22T15:55:30.956960211Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"185.125.190.56\",\"srcPort\":61584,\"dstPort\":123,\"proto\":\"TCP\",\"comm\":\"chronyd\",\"pid\":911,\"sourcePod\":\"kube-system/calico-node-cl2wn\",\"likelyService\":\"ntp\"}\r"}
{"created_at":"2025-08-22T15:55:31.952142Z","event_data":"{\"timestamp\":\"2025-08-22T15:55:31.952142691Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"85.23.93.164\",\"srcPort\":21636,\"dstPort\":123,\"proto\":\"TCP\",\"comm\":\"chronyd\",\"pid\":911,\"sourcePod\":\"kube-system/calico-node-cl2wn\",\"likelyService\":\"ntp\"}\r"}
{"created_at":"2025-08-22T15:55:31.956841Z","event_data":"{\"timestamp\":\"2025-08-22T15:55:31.956841252Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"195.148.70.12\",\"srcPort\":22492,\"dstPort\":123,\"proto\":\"TCP\",\"comm\":\"chronyd\",\"pid\":911,\"sourcePod\":\"kube-system/calico-node-cl2wn\",\"likelyService\":\"ntp\"}\r"}
{"created_at":"2025-08-22T15:55:31.962615Z","event_data":"{\"timestamp\":\"2025-08-22T15:55:31.962615999Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"95.216.78.223\",\"srcPort\":24043,\"dstPort\":123,\"proto\":\"TCP\",\"comm\":\"chronyd\",\"pid\":911,\"sourcePod\":\"kube-system/calico-node-cl2wn\",\"likelyService\":\"ntp\"}\r"}
{"created_at":"2025-08-22T15:55:32.951731Z","event_data":"{\"timestamp\":\"2025-08-22T15:55:32.951731355Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"91.189.91.157\",\"srcPort\":23980,\"dstPort\":123,\"proto\":\"TCP\",\"comm\":\"chronyd\",\"pid\":911,\"sourcePod\":\"kube-system/calico-node-cl2wn\",\"likelyService\":\"ntp\"}\r"}
{"created_at":"2025-08-22T15:55:32.956978Z","event_data":"{\"timestamp\":\"2025-08-22T15:55:32.95697893Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"95.217.220.251\",\"srcPort\":23967,\"dstPort\":123,\"proto\":\"TCP\",\"comm\":\"chronyd\",\"pid\":911,\"sourcePod\":\"kube-system/calico-node-cl2wn\",\"likelyService\":\"ntp\"}\r"}
{"created_at":"2025-08-22T15:56:20.951432Z","event_data":"{\"timestamp\":\"2025-08-22T15:56:20.951432Z\",\"srcIp\":\"fe80::785c:82ff:feab:440a\",\"dstIp\":\"ff02::2\",\"srcPort\":133,\"dstPort\":0,\"proto\":\"IPv6-ICMP\"}\r"}
{"created_at":"2025-08-22T15:56:34.951597Z","event_data":"{\"timestamp\":\"2025-08-22T15:56:34.951597245Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"185.125.190.57\",\"srcPort\":33971,\"dstPort\":123,\"proto\":\"TCP\",\"comm\":\"chronyd\",\"pid\":911,\"sourcePod\":\"kube-system/calico-node-cl2wn\",\"likelyService\":\"ntp\"}\r"}
{"created_at":"2025-08-22T15:56:34.951751Z","event_data":"{\"timestamp\":\"2025-08-22T15:56:34.951751624Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"185.125.190.56\",\"srcPort\":22174,\"dstPort\":123,\"proto\":\"TCP\",\"comm\":\"chronyd\",\"pid\":911,\"sourcePod\":\"kube-system/calico-node-cl2wn\",\"likelyService\":\"ntp\"}\r"}
{"created_at":"2025-08-22T15:56:35.951276Z","event_data":"{\"timestamp\":\"2025-08-22T15:56:35.951276272Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"185.125.190.58\",\"srcPort\":21919,\"dstPort\":123,\"proto\":\"TCP\",\"comm\":\"chronyd\",\"pid\":911,\"sourcePod\":\"kube-system/calico-node-cl2wn\",\"likelyService\":\"ntp\"}\r"}
{"created_at":"2025-08-22T15:56:36.951889Z","event_data":"{\"timestamp\":\"2025-08-22T15:56:36.951889371Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"85.23.93.164\",\"srcPort\":13996,\"dstPort\":123,\"proto\":\"TCP\",\"comm\":\"chronyd\",\"pid\":911,\"sourcePod\":\"kube-system/calico-node-cl2wn\",\"likelyService\":\"ntp\"}\r"}
{"created_at":"2025-08-22T15:56:36.952051Z","event_data":"{\"timestamp\":\"2025-08-22T15:56:36.952051125Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"195.148.70.12\",\"srcPort\":30083,\"dstPort\":123,\"proto\":\"TCP\",\"comm\":\"chronyd\",\"pid\":911,\"sourcePod\":\"kube-system/calico-node-cl2wn\",\"likelyService\":\"ntp\"}\r"}
{"created_at":"2025-08-22T15:56:36.952294Z","event_data":"{\"timestamp\":\"2025-08-22T15:56:36.952294937Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"95.216.78.223\",\"srcPort\":42438,\"dstPort\":123,\"proto\":\"TCP\",\"comm\":\"chronyd\",\"pid\":911,\"sourcePod\":\"kube-system/calico-node-cl2wn\",\"likelyService\":\"ntp\"}\r"}
{"created_at":"2025-08-22T15:56:36.95249Z","event_data":"{\"timestamp\":\"2025-08-22T15:56:36.952490577Z\",\"srcIp\":\"fe80::647a:e8ff:fe37:6021\",\"dstIp\":\"ff02::2\",\"srcPort\":133,\"dstPort\":0,\"proto\":\"IPv6-ICMP\"}\r"}
{"created_at":"2025-08-22T15:56:37.951674Z","event_data":"{\"timestamp\":\"2025-08-22T15:56:37.951674504Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"91.189.91.157\",\"srcPort\":47283,\"dstPort\":123,\"proto\":\"TCP\",\"comm\":\"chronyd\",\"pid\":911,\"sourcePod\":\"kube-system/calico-node-cl2wn\",\"likelyService\":\"ntp\"}\r"}
{"created_at":"2025-08-22T15:56:37.952084Z","event_data":"{\"timestamp\":\"2025-08-22T15:56:37.952084449Z\",\"srcIp\":\"10.0.0.11\",\"dstIp\":\"95.217.220.251\",\"srcPort\":59555,\"dstPort\":123,\"proto\":\"TCP\",\"comm\":\"chronyd\",\"pid\":911,\"sourcePod\":\"kube-system/calico-node-cl2wn\",\"likelyService\":\"ntp\"}\r"}
```