### PR TITLE
feat(kube): Add dynamic kubeconfig discovery and loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ FLAGS
   -?, --help                    display help
   -p, --plain                   if true, output in plain text format (default: JSON format)
   -u, --unique                  if true, only show the first instance of each connection
-  --kubeconfig STRING           path to kubeconfig file (Kubernetes lookups enabled if provided)
-  --external                    if true, only show traffic to external destinations
+  --kubeconfig STRING           path to kubeconfig file (Kubernetes lookups enabled if provided; if not set, kubeconfig auto-discovery is used by default)
+  -e, --external                    if true, only show traffic to external destinations
   --internal-networks STRING    comma-separated list of internal network CIDRs to filter out when using --external
                                 (default: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16)
   --version                     display program version
@@ -82,14 +82,4 @@ sudo apt install linux-headers-$(uname -r) \
                  linux-tools-generic
 ```
 
-### Testing a Release with Cluster Provisioner
-Build the test release of `pktstat-bpf`:
 
-```shell
-make generate build
-```
-
-Move the release into the `network-report-collector-path` set in
-`/etc/cluster-provisioner/cluster-provisioner.yaml` (default: `/opt/cluster-provisioner/bin/pktstat-bpf`) and spin up a cluster
-or VM.  Cluster Provisioner will use the binary at that path to collect
-network reports.

--- a/config_discovery.go
+++ b/config_discovery.go
@@ -1,0 +1,340 @@
+// @license
+// Copyright (C) 2024  Dinko Korunic
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// ConfigChangeCallback is called when a valid kubeconfig is found or changed
+type ConfigChangeCallback func(configPath string)
+
+// ConfigDiscovery manages kubeconfig discovery and monitoring
+type ConfigDiscovery interface {
+	// Start begins watching for kubeconfig files
+	Start(ctx context.Context) error
+
+	// GetCurrentPath returns the active kubeconfig path
+	GetCurrentPath() string
+
+	// Subscribe registers a callback for config changes
+	Subscribe(callback ConfigChangeCallback)
+}
+
+// configDiscovery is the concrete implementation of ConfigDiscovery
+type configDiscovery struct {
+	// Standard paths to scan for kubeconfig files
+	standardPaths []string
+
+	// Current active kubeconfig path
+	currentPath string
+
+	// Mutex to protect currentPath
+	pathMutex sync.RWMutex
+
+	// Callbacks to invoke when config changes
+	callbacks []ConfigChangeCallback
+
+	// Mutex to protect callbacks
+	callbackMutex sync.RWMutex
+
+	// Filesystem watcher
+	watcher *fsnotify.Watcher
+
+	// Whether discovery is running
+	running bool
+
+	// Mutex to protect running state
+	runningMutex sync.Mutex
+}
+
+// NewConfigDiscovery creates a new ConfigDiscovery instance
+func NewConfigDiscovery() ConfigDiscovery {
+	homeDir, _ := os.UserHomeDir()
+
+	return &configDiscovery{
+		standardPaths: []string{
+			os.Getenv("KUBECONFIG"),
+			filepath.Join(homeDir, ".kube", "config"),
+			"/tmp/kubeconfig-local",                               // kind
+			"/var/lib/rancher/k3s/agent/k3scontroller.kubeconfig", // k3s secondary nodes (must be before k3s control plane)
+			"/etc/rancher/k3s/k3s.yaml",                           // k3s control plane
+			"/etc/rancher/rke2/rke2.yaml",                         // rke2
+			"/var/lib/embedded-cluster/k0s/pki/admin.conf",        // embedded-cluster control plane
+			"/var/lib/embedded-cluster/k0s/kubelet.conf",          // embedded-cluster secondary nodes
+			"/var/home/core/kubeconfig",                           // openshift
+			"/etc/kubernetes/admin.conf",                          // kurl control plane
+			"/etc/kubernetes/kubelet.conf",                        // kurl secondary nodes
+		},
+		callbacks: make([]ConfigChangeCallback, 0),
+	}
+}
+
+// Start begins watching for kubeconfig files
+func (cd *configDiscovery) Start(ctx context.Context) error {
+	cd.runningMutex.Lock()
+	if cd.running {
+		cd.runningMutex.Unlock()
+		return fmt.Errorf("config discovery already running")
+	}
+	cd.running = true
+	cd.runningMutex.Unlock()
+
+	// Initialize filesystem watcher
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		cd.runningMutex.Lock()
+		cd.running = false
+		cd.runningMutex.Unlock()
+		return fmt.Errorf("failed to create filesystem watcher: %v", err)
+	}
+	cd.watcher = watcher
+
+	// Scan standard paths immediately
+	initialPath := cd.scanStandardPaths()
+	if initialPath != "" {
+		cd.setCurrentPath(initialPath)
+		cd.notifyCallbacks(initialPath)
+	}
+
+	// Watch directories for file creation/modification
+	cd.setupWatchers()
+
+	// Start watching goroutine
+	go cd.watchLoop(ctx)
+
+	return nil
+}
+
+// GetCurrentPath returns the active kubeconfig path
+func (cd *configDiscovery) GetCurrentPath() string {
+	cd.pathMutex.RLock()
+	defer cd.pathMutex.RUnlock()
+	return cd.currentPath
+}
+
+// Subscribe registers a callback for config changes
+func (cd *configDiscovery) Subscribe(callback ConfigChangeCallback) {
+	cd.callbackMutex.Lock()
+	defer cd.callbackMutex.Unlock()
+	cd.callbacks = append(cd.callbacks, callback)
+}
+
+// scanStandardPaths scans all standard paths and returns the first valid kubeconfig
+func (cd *configDiscovery) scanStandardPaths() string {
+	for _, path := range cd.standardPaths {
+		if path == "" {
+			continue
+		}
+
+		// Check if file exists
+		if _, err := os.Stat(path); err != nil {
+			continue
+		}
+
+		// Validate the kubeconfig
+		if cd.validateKubeconfig(path) {
+			log.Printf("Found valid kubeconfig at: %s", path)
+			return path
+		} else {
+			log.Printf("Found kubeconfig at %s but it is invalid", path)
+		}
+	}
+
+	return ""
+}
+
+// validateKubeconfig checks if a file is a valid kubeconfig
+func (cd *configDiscovery) validateKubeconfig(path string) bool {
+	// Try to load the config
+	_, err := clientcmd.LoadFromFile(path)
+	if err != nil {
+		log.Printf("Invalid kubeconfig at %s: %v", path, err)
+		return false
+	}
+
+	return true
+}
+
+// setupWatchers sets up filesystem watchers for kubeconfig directories
+func (cd *configDiscovery) setupWatchers() {
+	// Watch directories that might contain kubeconfig files
+	watchDirs := make(map[string]bool)
+
+	for _, path := range cd.standardPaths {
+		if path == "" {
+			continue
+		}
+
+		dir := filepath.Dir(path)
+		if _, ok := watchDirs[dir]; ok {
+			continue
+		}
+		watchDirs[dir] = true
+
+		// Check if directory exists
+		if _, err := os.Stat(dir); err != nil {
+			// Directory doesn't exist yet, try to watch parent
+			parentDir := filepath.Dir(dir)
+			if _, err := os.Stat(parentDir); err == nil {
+				_ = cd.watcher.Add(parentDir)
+				log.Printf("Watching parent directory for kubeconfig: %s", parentDir)
+			}
+			continue
+		}
+
+		// Watch the directory
+		err := cd.watcher.Add(dir)
+		if err != nil {
+			log.Printf("Failed to watch directory %s: %v", dir, err)
+		} else {
+			log.Printf("Watching directory for kubeconfig: %s", dir)
+		}
+	}
+}
+
+// watchLoop processes filesystem events
+func (cd *configDiscovery) watchLoop(ctx context.Context) {
+	defer cd.watcher.Close()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("Config discovery stopped")
+			cd.runningMutex.Lock()
+			cd.running = false
+			cd.runningMutex.Unlock()
+			return
+
+		case event, ok := <-cd.watcher.Events:
+			if !ok {
+				return
+			}
+
+			// Check if this event is for one of our watched paths
+			if cd.isWatchedPath(event.Name) {
+				if event.Op&fsnotify.Write == fsnotify.Write || event.Op&fsnotify.Create == fsnotify.Create {
+					log.Printf("Detected kubeconfig change: %s (op: %s)", event.Name, event.Op)
+
+					// Validate and potentially update current path
+					if cd.validateKubeconfig(event.Name) {
+						currentPath := cd.GetCurrentPath()
+						if currentPath != event.Name {
+							log.Printf("Switching to kubeconfig: %s", event.Name)
+							cd.setCurrentPath(event.Name)
+							cd.notifyCallbacks(event.Name)
+						} else {
+							log.Printf("Kubeconfig modified, reloading: %s", event.Name)
+							cd.notifyCallbacks(event.Name)
+						}
+					}
+				} else if event.Op&fsnotify.Remove == fsnotify.Remove {
+					currentPath := cd.GetCurrentPath()
+					if currentPath == event.Name {
+						log.Printf("Current kubeconfig removed: %s, searching for alternative", event.Name)
+						cd.setCurrentPath("")
+
+						// Try to find another valid config
+						newPath := cd.scanStandardPaths()
+						if newPath != "" {
+							cd.setCurrentPath(newPath)
+							cd.notifyCallbacks(newPath)
+						} else {
+							log.Printf("No alternative kubeconfig found")
+							// Notify callbacks with empty path to disable Kubernetes features
+							cd.notifyCallbacks("")
+						}
+					}
+				}
+			}
+
+			// If a directory was created, set up watchers for it
+			if event.Op&fsnotify.Create == fsnotify.Create {
+				if info, err := os.Stat(event.Name); err == nil && info.IsDir() {
+					if cd.shouldWatchDir(event.Name) {
+						_ = cd.watcher.Add(event.Name)
+						log.Printf("Started watching newly created directory: %s", event.Name)
+					}
+				}
+			}
+
+		case err, ok := <-cd.watcher.Errors:
+			if !ok {
+				return
+			}
+			log.Printf("Filesystem watcher error: %v", err)
+		}
+	}
+}
+
+// isWatchedPath checks if a path matches one of our standard paths
+func (cd *configDiscovery) isWatchedPath(path string) bool {
+	for _, standardPath := range cd.standardPaths {
+		if standardPath == "" {
+			continue
+		}
+		if path == standardPath {
+			return true
+		}
+	}
+	return false
+}
+
+// shouldWatchDir checks if we should watch a directory
+func (cd *configDiscovery) shouldWatchDir(dir string) bool {
+	for _, standardPath := range cd.standardPaths {
+		if standardPath == "" {
+			continue
+		}
+		if filepath.Dir(standardPath) == dir {
+			return true
+		}
+	}
+	return false
+}
+
+// setCurrentPath sets the current kubeconfig path
+func (cd *configDiscovery) setCurrentPath(path string) {
+	cd.pathMutex.Lock()
+	defer cd.pathMutex.Unlock()
+	cd.currentPath = path
+}
+
+// notifyCallbacks invokes all registered callbacks
+func (cd *configDiscovery) notifyCallbacks(path string) {
+	cd.callbackMutex.RLock()
+	callbacks := make([]ConfigChangeCallback, len(cd.callbacks))
+	copy(callbacks, cd.callbacks)
+	cd.callbackMutex.RUnlock()
+
+	for _, callback := range callbacks {
+		callback(path)
+	}
+}

--- a/config_discovery_test.go
+++ b/config_discovery_test.go
@@ -1,0 +1,364 @@
+// @license
+// Copyright (C) 2024  Dinko Korunic
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestConfigDiscovery_StandardPaths tests that config discovery scans standard paths
+func TestConfigDiscovery_StandardPaths(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir, err := os.MkdirTemp("", "kubeconfig-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create a valid kubeconfig file
+	kubeconfigPath := filepath.Join(tmpDir, "config")
+	validKubeconfig := `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user:
+    token: test-token
+`
+	if err := os.WriteFile(kubeconfigPath, []byte(validKubeconfig), 0600); err != nil {
+		t.Fatalf("Failed to write kubeconfig: %v", err)
+	}
+
+	// Create discovery with custom paths
+	discovery := &configDiscovery{
+		standardPaths: []string{kubeconfigPath},
+		callbacks:     make([]ConfigChangeCallback, 0),
+	}
+
+	// Scan for config
+	foundPath := discovery.scanStandardPaths()
+	if foundPath == "" {
+		t.Fatal("Expected to find kubeconfig, but none was found")
+	}
+
+	if foundPath != kubeconfigPath {
+		t.Errorf("Expected path %s, got %s", kubeconfigPath, foundPath)
+	}
+}
+
+// TestConfigDiscovery_FileAppears tests that discovery detects when a kubeconfig file is created
+func TestConfigDiscovery_FileAppears(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir, err := os.MkdirTemp("", "kubeconfig-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	kubeconfigPath := filepath.Join(tmpDir, "config")
+
+	// Create discovery with custom paths
+	discovery := &configDiscovery{
+		standardPaths: []string{kubeconfigPath},
+		callbacks:     make([]ConfigChangeCallback, 0),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Channel to signal when callback is invoked
+	callbackChan := make(chan string, 1)
+
+	// Subscribe to changes
+	discovery.Subscribe(func(configPath string) {
+		callbackChan <- configPath
+	})
+
+	// Start discovery
+	if err := discovery.Start(ctx); err != nil {
+		t.Fatalf("Failed to start discovery: %v", err)
+	}
+
+	// Give watcher time to initialize
+	time.Sleep(100 * time.Millisecond)
+
+	// Create the kubeconfig file
+	validKubeconfig := `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user:
+    token: test-token
+`
+	if err := os.WriteFile(kubeconfigPath, []byte(validKubeconfig), 0600); err != nil {
+		t.Fatalf("Failed to write kubeconfig: %v", err)
+	}
+
+	// Wait for callback
+	select {
+	case path := <-callbackChan:
+		if path != kubeconfigPath {
+			t.Errorf("Expected callback with path %s, got %s", kubeconfigPath, path)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for callback after file creation")
+	}
+}
+
+// TestConfigDiscovery_FileRemoved tests that discovery handles file removal
+func TestConfigDiscovery_FileRemoved(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir, err := os.MkdirTemp("", "kubeconfig-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	kubeconfigPath := filepath.Join(tmpDir, "config")
+
+	// Create initial kubeconfig
+	validKubeconfig := `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user:
+    token: test-token
+`
+	if err := os.WriteFile(kubeconfigPath, []byte(validKubeconfig), 0600); err != nil {
+		t.Fatalf("Failed to write kubeconfig: %v", err)
+	}
+
+	// Create discovery with custom paths
+	discovery := &configDiscovery{
+		standardPaths: []string{kubeconfigPath},
+		callbacks:     make([]ConfigChangeCallback, 0),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Channel to signal when callback is invoked
+	callbackChan := make(chan string, 2)
+
+	// Subscribe to changes
+	discovery.Subscribe(func(configPath string) {
+		callbackChan <- configPath
+	})
+
+	// Start discovery
+	if err := discovery.Start(ctx); err != nil {
+		t.Fatalf("Failed to start discovery: %v", err)
+	}
+
+	// Wait for initial callback
+	select {
+	case path := <-callbackChan:
+		if path != kubeconfigPath {
+			t.Errorf("Expected initial callback with path %s, got %s", kubeconfigPath, path)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("Timeout waiting for initial callback")
+	}
+
+	// Remove the file
+	if err := os.Remove(kubeconfigPath); err != nil {
+		t.Fatalf("Failed to remove kubeconfig: %v", err)
+	}
+
+	// Wait for callback after removal
+	select {
+	case path := <-callbackChan:
+		if path != "" {
+			t.Errorf("Expected callback with empty path after removal, got %s", path)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for callback after file removal")
+	}
+
+	// Verify current path is empty
+	if discovery.GetCurrentPath() != "" {
+		t.Errorf("Expected current path to be empty, got %s", discovery.GetCurrentPath())
+	}
+}
+
+// TestConfigDiscovery_FileModified tests that discovery detects file modifications
+func TestConfigDiscovery_FileModified(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir, err := os.MkdirTemp("", "kubeconfig-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	kubeconfigPath := filepath.Join(tmpDir, "config")
+
+	// Create initial kubeconfig
+	validKubeconfig := `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user:
+    token: test-token
+`
+	if err := os.WriteFile(kubeconfigPath, []byte(validKubeconfig), 0600); err != nil {
+		t.Fatalf("Failed to write kubeconfig: %v", err)
+	}
+
+	// Create discovery with custom paths
+	discovery := &configDiscovery{
+		standardPaths: []string{kubeconfigPath},
+		callbacks:     make([]ConfigChangeCallback, 0),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Channel to signal when callback is invoked
+	callbackChan := make(chan string, 2)
+
+	// Subscribe to changes
+	discovery.Subscribe(func(configPath string) {
+		callbackChan <- configPath
+	})
+
+	// Start discovery
+	if err := discovery.Start(ctx); err != nil {
+		t.Fatalf("Failed to start discovery: %v", err)
+	}
+
+	// Wait for initial callback
+	select {
+	case <-callbackChan:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Timeout waiting for initial callback")
+	}
+
+	// Modify the file
+	modifiedKubeconfig := `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://127.0.0.1:6444
+  name: test-cluster-modified
+contexts:
+- context:
+    cluster: test-cluster-modified
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user:
+    token: test-token-modified
+`
+	if err := os.WriteFile(kubeconfigPath, []byte(modifiedKubeconfig), 0600); err != nil {
+		t.Fatalf("Failed to modify kubeconfig: %v", err)
+	}
+
+	// Wait for callback after modification
+	select {
+	case path := <-callbackChan:
+		if path != kubeconfigPath {
+			t.Errorf("Expected callback with path %s after modification, got %s", kubeconfigPath, path)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for callback after file modification")
+	}
+}
+
+// TestConfigDiscovery_InvalidConfig tests handling of invalid kubeconfig files
+func TestConfigDiscovery_InvalidConfig(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir, err := os.MkdirTemp("", "kubeconfig-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	kubeconfigPath := filepath.Join(tmpDir, "config")
+
+	// Create invalid kubeconfig
+	invalidKubeconfig := `this is not valid yaml: {[[`
+	if err := os.WriteFile(kubeconfigPath, []byte(invalidKubeconfig), 0600); err != nil {
+		t.Fatalf("Failed to write kubeconfig: %v", err)
+	}
+
+	// Create discovery with custom paths
+	discovery := &configDiscovery{
+		standardPaths: []string{kubeconfigPath},
+		callbacks:     make([]ConfigChangeCallback, 0),
+	}
+
+	// Scan for config - should not find invalid config
+	foundPath := discovery.scanStandardPaths()
+	if foundPath != "" {
+		t.Errorf("Expected not to find invalid kubeconfig, but found: %s", foundPath)
+	}
+
+	// Verify validation rejects invalid config
+	if discovery.validateKubeconfig(kubeconfigPath) {
+		t.Error("Expected validateKubeconfig to reject invalid config")
+	}
+}

--- a/dynamic_client.go
+++ b/dynamic_client.go
@@ -1,0 +1,136 @@
+// @license
+// Copyright (C) 2024  Dinko Korunic
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package main
+
+import (
+	"log"
+	"sync"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// DynamicKubeClient wraps kubernetes.Clientset with dynamic behavior
+type DynamicKubeClient interface {
+	// GetClient returns current client or nil if unavailable
+	GetClient() *kubernetes.Clientset
+
+	// Refresh attempts to reinitialize the client with a new config path
+	Refresh(configPath string) error
+
+	// IsAvailable indicates if client is ready for use
+	IsAvailable() bool
+
+	// Shutdown gracefully closes the client
+	Shutdown()
+}
+
+// dynamicKubeClient is the concrete implementation
+type dynamicKubeClient struct {
+	client     *kubernetes.Clientset
+	configPath string
+	mutex      sync.RWMutex
+}
+
+// NewDynamicKubeClient creates a new DynamicKubeClient
+func NewDynamicKubeClient() DynamicKubeClient {
+	return &dynamicKubeClient{}
+}
+
+// GetClient returns the current Kubernetes client or nil if unavailable
+func (d *dynamicKubeClient) GetClient() *kubernetes.Clientset {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	return d.client
+}
+
+// Refresh reinitializes the client with a new config path
+func (d *dynamicKubeClient) Refresh(configPath string) error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	// If configPath is empty, shutdown the client
+	if configPath == "" {
+		log.Printf("Shutting down Kubernetes client (no config available)")
+		d.client = nil
+		d.configPath = ""
+		return nil
+	}
+
+	// If this is the same path and client is already initialized, no action needed
+	if d.configPath == configPath && d.client != nil {
+		log.Printf("Reloading Kubernetes client with config: %s", configPath)
+		// Even if it's the same path, the file might have been modified
+		// So we proceed with reinitialization
+	}
+
+	// Build config from the provided path
+	var config *rest.Config
+	var err error
+
+	config, err = clientcmd.BuildConfigFromFlags("", configPath)
+	if err != nil {
+		log.Printf("Failed to build Kubernetes config from %s: %v", configPath, err)
+		return err
+	}
+
+	// Create new client
+	newClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		log.Printf("Failed to create Kubernetes client: %v", err)
+		return err
+	}
+
+	// Close existing client if present (graceful shutdown)
+	if d.client != nil {
+		// The kubernetes.Clientset doesn't have an explicit Close method,
+		// but we can nil it out to allow garbage collection
+		d.client = nil
+	}
+
+	// Update to new client
+	d.client = newClient
+	d.configPath = configPath
+
+	log.Printf("Kubernetes client initialized with kubeconfig: %s", configPath)
+	return nil
+}
+
+// IsAvailable indicates if the client is ready for use
+func (d *dynamicKubeClient) IsAvailable() bool {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	return d.client != nil
+}
+
+// Shutdown gracefully closes the client
+func (d *dynamicKubeClient) Shutdown() {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	if d.client != nil {
+		log.Printf("Shutting down Kubernetes client")
+		d.client = nil
+		d.configPath = ""
+	}
+}

--- a/dynamic_client_test.go
+++ b/dynamic_client_test.go
@@ -1,0 +1,340 @@
+// @license
+// Copyright (C) 2024  Dinko Korunic
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// TestDynamicClient_Initialization tests basic client initialization
+func TestDynamicClient_Initialization(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir, err := os.MkdirTemp("", "kubeconfig-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	kubeconfigPath := filepath.Join(tmpDir, "config")
+
+	// Create a valid kubeconfig file
+	validKubeconfig := `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user:
+    token: test-token
+`
+	if err := os.WriteFile(kubeconfigPath, []byte(validKubeconfig), 0600); err != nil {
+		t.Fatalf("Failed to write kubeconfig: %v", err)
+	}
+
+	// Create dynamic client
+	client := NewDynamicKubeClient()
+
+	// Initially should not be available
+	if client.IsAvailable() {
+		t.Error("Expected client to not be available before initialization")
+	}
+
+	if client.GetClient() != nil {
+		t.Error("Expected GetClient to return nil before initialization")
+	}
+
+	// Initialize with kubeconfig
+	err = client.Refresh(kubeconfigPath)
+	if err != nil {
+		t.Fatalf("Failed to initialize client: %v", err)
+	}
+
+	// Should now be available
+	if !client.IsAvailable() {
+		t.Error("Expected client to be available after initialization")
+	}
+
+	if client.GetClient() == nil {
+		t.Error("Expected GetClient to return non-nil after initialization")
+	}
+}
+
+// TestDynamicClient_Reinitialize tests client reinitialization
+func TestDynamicClient_Reinitialize(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir, err := os.MkdirTemp("", "kubeconfig-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	kubeconfigPath1 := filepath.Join(tmpDir, "config1")
+	kubeconfigPath2 := filepath.Join(tmpDir, "config2")
+
+	// Create two valid kubeconfig files
+	validKubeconfig1 := `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+  name: test-cluster-1
+contexts:
+- context:
+    cluster: test-cluster-1
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user:
+    token: test-token-1
+`
+	validKubeconfig2 := `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://127.0.0.1:6444
+  name: test-cluster-2
+contexts:
+- context:
+    cluster: test-cluster-2
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user:
+    token: test-token-2
+`
+	if err := os.WriteFile(kubeconfigPath1, []byte(validKubeconfig1), 0600); err != nil {
+		t.Fatalf("Failed to write kubeconfig1: %v", err)
+	}
+	if err := os.WriteFile(kubeconfigPath2, []byte(validKubeconfig2), 0600); err != nil {
+		t.Fatalf("Failed to write kubeconfig2: %v", err)
+	}
+
+	// Create dynamic client
+	client := NewDynamicKubeClient()
+
+	// Initialize with first kubeconfig
+	err = client.Refresh(kubeconfigPath1)
+	if err != nil {
+		t.Fatalf("Failed to initialize client with config1: %v", err)
+	}
+
+	if !client.IsAvailable() {
+		t.Error("Expected client to be available after first initialization")
+	}
+
+	firstClient := client.GetClient()
+	if firstClient == nil {
+		t.Fatal("Expected GetClient to return non-nil after first initialization")
+	}
+
+	// Reinitialize with second kubeconfig
+	err = client.Refresh(kubeconfigPath2)
+	if err != nil {
+		t.Fatalf("Failed to reinitialize client with config2: %v", err)
+	}
+
+	if !client.IsAvailable() {
+		t.Error("Expected client to be available after reinitialization")
+	}
+
+	secondClient := client.GetClient()
+	if secondClient == nil {
+		t.Fatal("Expected GetClient to return non-nil after reinitialization")
+	}
+
+	// The clients should be different instances
+	if firstClient == secondClient {
+		t.Error("Expected different client instances after reinitialization")
+	}
+}
+
+// TestDynamicClient_ConcurrentAccess tests concurrent access to the client
+func TestDynamicClient_ConcurrentAccess(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir, err := os.MkdirTemp("", "kubeconfig-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	kubeconfigPath := filepath.Join(tmpDir, "config")
+
+	// Create a valid kubeconfig file
+	validKubeconfig := `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user:
+    token: test-token
+`
+	if err := os.WriteFile(kubeconfigPath, []byte(validKubeconfig), 0600); err != nil {
+		t.Fatalf("Failed to write kubeconfig: %v", err)
+	}
+
+	// Create dynamic client
+	client := NewDynamicKubeClient()
+
+	// Initialize client
+	err = client.Refresh(kubeconfigPath)
+	if err != nil {
+		t.Fatalf("Failed to initialize client: %v", err)
+	}
+
+	// Perform concurrent reads and writes
+	var wg sync.WaitGroup
+	iterations := 100
+
+	// Concurrent readers
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				_ = client.GetClient()
+				_ = client.IsAvailable()
+			}
+		}()
+	}
+
+	// Concurrent writers (reinitializing)
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations/10; j++ {
+				_ = client.Refresh(kubeconfigPath)
+			}
+		}()
+	}
+
+	// Wait for all goroutines to complete
+	wg.Wait()
+
+	// Client should still be available after concurrent access
+	if !client.IsAvailable() {
+		t.Error("Expected client to be available after concurrent access")
+	}
+}
+
+// TestDynamicClient_GracefulShutdown tests graceful shutdown
+func TestDynamicClient_GracefulShutdown(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir, err := os.MkdirTemp("", "kubeconfig-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	kubeconfigPath := filepath.Join(tmpDir, "config")
+
+	// Create a valid kubeconfig file
+	validKubeconfig := `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user:
+    token: test-token
+`
+	if err := os.WriteFile(kubeconfigPath, []byte(validKubeconfig), 0600); err != nil {
+		t.Fatalf("Failed to write kubeconfig: %v", err)
+	}
+
+	// Create dynamic client
+	client := NewDynamicKubeClient()
+
+	// Initialize client
+	err = client.Refresh(kubeconfigPath)
+	if err != nil {
+		t.Fatalf("Failed to initialize client: %v", err)
+	}
+
+	if !client.IsAvailable() {
+		t.Error("Expected client to be available after initialization")
+	}
+
+	// Shutdown the client
+	client.Shutdown()
+
+	// Client should not be available after shutdown
+	if client.IsAvailable() {
+		t.Error("Expected client to not be available after shutdown")
+	}
+
+	if client.GetClient() != nil {
+		t.Error("Expected GetClient to return nil after shutdown")
+	}
+
+	// Test refresh with empty path (similar to shutdown)
+	err = client.Refresh(kubeconfigPath)
+	if err != nil {
+		t.Fatalf("Failed to reinitialize after shutdown: %v", err)
+	}
+
+	if !client.IsAvailable() {
+		t.Error("Expected client to be available after reinitialization")
+	}
+
+	// Refresh with empty path should disable client
+	err = client.Refresh("")
+	if err != nil {
+		t.Fatalf("Failed to disable client: %v", err)
+	}
+
+	if client.IsAvailable() {
+		t.Error("Expected client to not be available after empty path refresh")
+	}
+}

--- a/flags.go
+++ b/flags.go
@@ -39,8 +39,8 @@ func parseFlags() {
 
 	help = fs.Bool('?', "help", "display help")
 	uniqueOutput = fs.Bool('u', "unique", "if true, only show the first instance of each connection")
-	kubeconfig = fs.StringLong("kubeconfig", "", "path to kubeconfig file (Kubernetes lookups enabled if provided)")
-	externalOnly = fs.BoolLong("external", "if true, only show traffic to external destinations")
+	kubeconfig = fs.StringLong("kubeconfig", "", "path to kubeconfig file (if not set, dynamic kubeconfig discovery is used)")
+	externalOnly = fs.Bool('e', "external", "if true, only show traffic to external destinations")
 	version = fs.BoolLong("version", "display program version")
 
 	var err error

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.24.1
 
 require (
 	github.com/cilium/ebpf v0.18.0
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/goccy/go-json v0.10.5
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/peterbourgon/ff/v4 v4.0.0-alpha.4

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=


### PR DESCRIPTION
This PR adds kubeconfig auto discovery and loading.  Now, instead of requiring a user to specify `--kubeconfig` we check known kubeconfig paths for known distros we support and try to load the kubeconfig from there.  If a kubeconfig is found we immediately start using it to improve the output with `sourcePod` lookups.

Check the linked PR for e2e test results and other manual testing.