### PR TITLE
feat: use kprobes to capture dns packets

### DIFF
--- a/counter_x86_bpfel.go
+++ b/counter_x86_bpfel.go
@@ -12,22 +12,6 @@ import (
 	"github.com/cilium/ebpf"
 )
 
-type counterAddrinfoArgsCache struct {
-	AddrinfoPtr uint64
-	Node        [256]int8
-	Pid         int32
-	Comm        [16]int8
-	_           [4]byte
-}
-
-type counterDnsLookupEvent struct {
-	AddrType uint32
-	Ip       [16]uint8
-	Host     [252]int8
-	Pid      int32
-	Comm     [16]int8
-}
-
 type counterSockinfo struct {
 	Comm [16]uint8
 	Pid  int32
@@ -47,6 +31,11 @@ type counterStatkey struct {
 type counterStatvalue struct {
 	Packets uint64
 	Bytes   uint64
+}
+
+type counterUdpPkt struct {
+	Pid int32
+	Pkt [4096]uint8
 }
 
 // loadCounter returns the embedded CollectionSpec for counter.
@@ -91,43 +80,37 @@ type counterSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type counterProgramSpecs struct {
-	IcmpSend             *ebpf.ProgramSpec `ebpf:"__icmp_send"`
-	CgroupSkbEgress      *ebpf.ProgramSpec `ebpf:"cgroup_skb_egress"`
-	CgroupSkbIngress     *ebpf.ProgramSpec `ebpf:"cgroup_skb_ingress"`
-	CgroupSockCreate     *ebpf.ProgramSpec `ebpf:"cgroup_sock_create"`
-	Icmp6Send            *ebpf.ProgramSpec `ebpf:"icmp6_send"`
-	IcmpRcv              *ebpf.ProgramSpec `ebpf:"icmp_rcv"`
-	Icmpv6Rcv            *ebpf.ProgramSpec `ebpf:"icmpv6_rcv"`
-	IpLocalOutFn         *ebpf.ProgramSpec `ebpf:"ip_local_out_fn"`
-	IpOutputFn           *ebpf.ProgramSpec `ebpf:"ip_output_fn"`
-	IpSendSkb            *ebpf.ProgramSpec `ebpf:"ip_send_skb"`
-	SkbConsumeUdp        *ebpf.ProgramSpec `ebpf:"skb_consume_udp"`
-	TcCountPackets       *ebpf.ProgramSpec `ebpf:"tc_count_packets"`
-	TcpCleanupRbuf       *ebpf.ProgramSpec `ebpf:"tcp_cleanup_rbuf"`
-	TcpSendmsg           *ebpf.ProgramSpec `ebpf:"tcp_sendmsg"`
-	UprobeGetaddrinfo    *ebpf.ProgramSpec `ebpf:"uprobe__getaddrinfo"`
-	UprobeGethostbyname  *ebpf.ProgramSpec `ebpf:"uprobe__gethostbyname"`
-	UprobeGethostbyname2 *ebpf.ProgramSpec `ebpf:"uprobe__gethostbyname2"`
-	UprobeGethostbynameR *ebpf.ProgramSpec `ebpf:"uprobe__gethostbyname_r"`
-	XdpCountPackets      *ebpf.ProgramSpec `ebpf:"xdp_count_packets"`
+	IcmpSend         *ebpf.ProgramSpec `ebpf:"__icmp_send"`
+	CgroupSkbEgress  *ebpf.ProgramSpec `ebpf:"cgroup_skb_egress"`
+	CgroupSkbIngress *ebpf.ProgramSpec `ebpf:"cgroup_skb_ingress"`
+	CgroupSockCreate *ebpf.ProgramSpec `ebpf:"cgroup_sock_create"`
+	Icmp6Send        *ebpf.ProgramSpec `ebpf:"icmp6_send"`
+	IcmpRcv          *ebpf.ProgramSpec `ebpf:"icmp_rcv"`
+	Icmpv6Rcv        *ebpf.ProgramSpec `ebpf:"icmpv6_rcv"`
+	IpLocalOutFn     *ebpf.ProgramSpec `ebpf:"ip_local_out_fn"`
+	IpOutputFn       *ebpf.ProgramSpec `ebpf:"ip_output_fn"`
+	IpSendSkb        *ebpf.ProgramSpec `ebpf:"ip_send_skb"`
+	SkbConsumeUdp    *ebpf.ProgramSpec `ebpf:"skb_consume_udp"`
+	TcCountPackets   *ebpf.ProgramSpec `ebpf:"tc_count_packets"`
+	TcpCleanupRbuf   *ebpf.ProgramSpec `ebpf:"tcp_cleanup_rbuf"`
+	TcpSendmsg       *ebpf.ProgramSpec `ebpf:"tcp_sendmsg"`
+	XdpCountPackets  *ebpf.ProgramSpec `ebpf:"xdp_count_packets"`
 }
 
 // counterMapSpecs contains maps before they are loaded into the kernel.
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type counterMapSpecs struct {
-	AddrinfoArgsHash *ebpf.MapSpec `ebpf:"addrinfo_args_hash"`
-	DnsEvents        *ebpf.MapSpec `ebpf:"dns_events"`
-	DnsLookupHeap    *ebpf.MapSpec `ebpf:"dns_lookup_heap"`
 	PktCount         *ebpf.MapSpec `ebpf:"pkt_count"`
 	SockInfo         *ebpf.MapSpec `ebpf:"sock_info"`
+	UdpPktLookupHeap *ebpf.MapSpec `ebpf:"udp_pkt_lookup_heap"`
+	UdpPkts          *ebpf.MapSpec `ebpf:"udp_pkts"`
 }
 
 // counterVariableSpecs contains global variables before they are loaded into the kernel.
 //
 // It can be passed ebpf.CollectionSpec.Assign.
-type counterVariableSpecs struct {
-}
+type counterVariableSpecs struct{}
 
 // counterObjects contains all objects after they have been loaded into the kernel.
 //
@@ -149,52 +132,45 @@ func (o *counterObjects) Close() error {
 //
 // It can be passed to loadCounterObjects or ebpf.CollectionSpec.LoadAndAssign.
 type counterMaps struct {
-	AddrinfoArgsHash *ebpf.Map `ebpf:"addrinfo_args_hash"`
-	DnsEvents        *ebpf.Map `ebpf:"dns_events"`
-	DnsLookupHeap    *ebpf.Map `ebpf:"dns_lookup_heap"`
 	PktCount         *ebpf.Map `ebpf:"pkt_count"`
 	SockInfo         *ebpf.Map `ebpf:"sock_info"`
+	UdpPktLookupHeap *ebpf.Map `ebpf:"udp_pkt_lookup_heap"`
+	UdpPkts          *ebpf.Map `ebpf:"udp_pkts"`
 }
 
 func (m *counterMaps) Close() error {
 	return _CounterClose(
-		m.AddrinfoArgsHash,
-		m.DnsEvents,
-		m.DnsLookupHeap,
 		m.PktCount,
 		m.SockInfo,
+		m.UdpPktLookupHeap,
+		m.UdpPkts,
 	)
 }
 
 // counterVariables contains all global variables after they have been loaded into the kernel.
 //
 // It can be passed to loadCounterObjects or ebpf.CollectionSpec.LoadAndAssign.
-type counterVariables struct {
-}
+type counterVariables struct{}
 
 // counterPrograms contains all programs after they have been loaded into the kernel.
 //
 // It can be passed to loadCounterObjects or ebpf.CollectionSpec.LoadAndAssign.
 type counterPrograms struct {
-	IcmpSend             *ebpf.Program `ebpf:"__icmp_send"`
-	CgroupSkbEgress      *ebpf.Program `ebpf:"cgroup_skb_egress"`
-	CgroupSkbIngress     *ebpf.Program `ebpf:"cgroup_skb_ingress"`
-	CgroupSockCreate     *ebpf.Program `ebpf:"cgroup_sock_create"`
-	Icmp6Send            *ebpf.Program `ebpf:"icmp6_send"`
-	IcmpRcv              *ebpf.Program `ebpf:"icmp_rcv"`
-	Icmpv6Rcv            *ebpf.Program `ebpf:"icmpv6_rcv"`
-	IpLocalOutFn         *ebpf.Program `ebpf:"ip_local_out_fn"`
-	IpOutputFn           *ebpf.Program `ebpf:"ip_output_fn"`
-	IpSendSkb            *ebpf.Program `ebpf:"ip_send_skb"`
-	SkbConsumeUdp        *ebpf.Program `ebpf:"skb_consume_udp"`
-	TcCountPackets       *ebpf.Program `ebpf:"tc_count_packets"`
-	TcpCleanupRbuf       *ebpf.Program `ebpf:"tcp_cleanup_rbuf"`
-	TcpSendmsg           *ebpf.Program `ebpf:"tcp_sendmsg"`
-	UprobeGetaddrinfo    *ebpf.Program `ebpf:"uprobe__getaddrinfo"`
-	UprobeGethostbyname  *ebpf.Program `ebpf:"uprobe__gethostbyname"`
-	UprobeGethostbyname2 *ebpf.Program `ebpf:"uprobe__gethostbyname2"`
-	UprobeGethostbynameR *ebpf.Program `ebpf:"uprobe__gethostbyname_r"`
-	XdpCountPackets      *ebpf.Program `ebpf:"xdp_count_packets"`
+	IcmpSend         *ebpf.Program `ebpf:"__icmp_send"`
+	CgroupSkbEgress  *ebpf.Program `ebpf:"cgroup_skb_egress"`
+	CgroupSkbIngress *ebpf.Program `ebpf:"cgroup_skb_ingress"`
+	CgroupSockCreate *ebpf.Program `ebpf:"cgroup_sock_create"`
+	Icmp6Send        *ebpf.Program `ebpf:"icmp6_send"`
+	IcmpRcv          *ebpf.Program `ebpf:"icmp_rcv"`
+	Icmpv6Rcv        *ebpf.Program `ebpf:"icmpv6_rcv"`
+	IpLocalOutFn     *ebpf.Program `ebpf:"ip_local_out_fn"`
+	IpOutputFn       *ebpf.Program `ebpf:"ip_output_fn"`
+	IpSendSkb        *ebpf.Program `ebpf:"ip_send_skb"`
+	SkbConsumeUdp    *ebpf.Program `ebpf:"skb_consume_udp"`
+	TcCountPackets   *ebpf.Program `ebpf:"tc_count_packets"`
+	TcpCleanupRbuf   *ebpf.Program `ebpf:"tcp_cleanup_rbuf"`
+	TcpSendmsg       *ebpf.Program `ebpf:"tcp_sendmsg"`
+	XdpCountPackets  *ebpf.Program `ebpf:"xdp_count_packets"`
 }
 
 func (p *counterPrograms) Close() error {
@@ -213,10 +189,6 @@ func (p *counterPrograms) Close() error {
 		p.TcCountPackets,
 		p.TcpCleanupRbuf,
 		p.TcpSendmsg,
-		p.UprobeGetaddrinfo,
-		p.UprobeGethostbyname,
-		p.UprobeGethostbyname2,
-		p.UprobeGethostbynameR,
 		p.XdpCountPackets,
 	)
 }

--- a/dns.go
+++ b/dns.go
@@ -5,72 +5,68 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"log"
 	"sync"
-	"time"
 
 	"github.com/cilium/ebpf/ringbuf"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
 )
 
-func processDNSEvents(ctx context.Context, reader *ringbuf.Reader, dnsLookupMap map[uint32]string, dnsLookupMapMutex *sync.RWMutex) error {
-	perfChan := make(chan []byte, 0)
-
-	go func(perfChan chan []byte, reader *ringbuf.Reader) {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-				record, err := reader.Read()
-				if err != nil {
-					if errors.Is(err, ringbuf.ErrClosed) {
-						return
-					}
-					log.Printf("Error reading DNS event: %v", err)
-					continue
-				}
-				perfChan <- record.RawSample
-			}
-		}
-	}(perfChan, reader)
-
-	var event dnsLookupEvent
-
+func processUDPPackets(ctx context.Context, reader *ringbuf.Reader, dnsLookupMap map[uint32]string, dnsLookupMapMutex *sync.RWMutex) {
 	for {
 		select {
-		case <-time.After(1 * time.Millisecond):
-			continue
 		case <-ctx.Done():
-			return nil
+			return
 		default:
-			record, ok := <-perfChan
-			if !ok {
-				panic("perfChan closed")
-			}
-			err := binary.Read(bytes.NewReader(record), binary.LittleEndian, &event)
+			record, err := reader.Read()
 			if err != nil {
-				log.Printf("Error reading DNS event: %v", err)
+				if errors.Is(err, ringbuf.ErrClosed) {
+					return
+				}
+
+				log.Printf("Error reading UDP Packet: %v", err)
 				continue
 			}
 
-			hostname := nullTerminatedString(event.Host[:])
-
-			// Store PID to hostname mapping for all DNS events that have a hostname
-			if hostname != "" {
-				dnsLookupMapMutex.Lock()
-				dnsLookupMap[event.Pid] = hostname
-				dnsLookupMapMutex.Unlock()
+			udpPktDetails, packet, err := parseUDPPacketRecord(record)
+			if err != nil {
+				log.Printf("Error handling UDP Packet: %v", err)
+				continue
 			}
+
+			layer := packet.Layer(layers.LayerTypeDNS)
+			if layer == nil {
+				log.Printf("Skipping udp packet: does not contain a dns layer")
+				continue
+			}
+
+			dnsLayer, ok := layer.(*layers.DNS)
+			if !ok {
+				log.Printf("Skipping udp packet: couldn't convert to dns layer")
+				continue
+			}
+
+			if len(dnsLayer.Questions) == 0 {
+				log.Printf("Skipping dns packet: no questions")
+			}
+
+			// just grab the first question for now
+			dnsLookupMapMutex.Lock()
+			dnsLookupMap[uint32(udpPktDetails.Pid)] = string(dnsLayer.Questions[0].Name)
+			dnsLookupMapMutex.Unlock()
 		}
 	}
 }
 
-// Helper function to extract null-terminated strings from byte arrays
-func nullTerminatedString(data []byte) string {
-	for i, b := range data {
-		if b == 0 {
-			return string(data[:i])
-		}
+func parseUDPPacketRecord(rec ringbuf.Record) (counterUdpPkt, gopacket.Packet, error) {
+	udpPkt := counterUdpPkt{}
+	if err := binary.Read(bytes.NewReader(rec.RawSample), binary.LittleEndian, &udpPkt); err != nil {
+		return udpPkt, nil, fmt.Errorf("reading record: %w", err)
 	}
-	return string(data)
+
+	pktBytes := [4096]byte(udpPkt.Pkt)
+	parsedPacket := gopacket.NewPacket(pktBytes[:], layers.LayerTypeDNS, gopacket.DecodeOptions{NoCopy: true})
+	return udpPkt, parsedPacket, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cilium/ebpf v0.18.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/goccy/go-json v0.10.5
+	github.com/google/gopacket v1.1.19
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/peterbourgon/ff/v4 v4.0.0-alpha.4
 	k8s.io/apimachinery v0.33.1

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
+github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgYQBbFN4U4JNXUNYpxael3UzMyo=
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -106,6 +108,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -136,6 +140,7 @@ golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
 golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.26.0 h1:v/60pFQmzmT9ExmjDv2gGIfi3OqfKoEP6I5+umXlbnQ=


### PR DESCRIPTION
Currently we use uprobes attached to the VM's glibc to intercept calls to `getaddrinfo`, `gethostbyname`, and other related function calls. This works really well to tell what host the process is reaching out to, and being able to get information on the process that is reaching out.

However, this has the downside that anything that doesn't use these functions or uses some other instance of glibc is missed. For example, any CGO-less binary will not use glibc, containerized workloads may bring their own glibc that we aren't attached to or may use musl.

This instead uses kprobes that we already had attached to the relevant udp sending/receiving kernel functions to look for likely DNS packets and forward them into user space to parse and correlate with other events that we observe, similarly to how we use the uprobe information today.