### PR TITLE
chore: no longer correlate other events to dns events

### DIFF
--- a/counter_arm64_bpfel.go
+++ b/counter_arm64_bpfel.go
@@ -34,8 +34,13 @@ type counterStatvalue struct {
 }
 
 type counterUdpPkt struct {
-	Pid int32
-	Pkt [4096]uint8
+	Srcip   struct{ In6U struct{ U6Addr8 [16]uint8 } }
+	Dstip   struct{ In6U struct{ U6Addr8 [16]uint8 } }
+	SrcPort uint16
+	DstPort uint16
+	Pid     int32
+	Comm    [16]int8
+	Pkt     [4096]uint8
 }
 
 // loadCounter returns the embedded CollectionSpec for counter.

--- a/counter_x86_bpfel.go
+++ b/counter_x86_bpfel.go
@@ -34,8 +34,13 @@ type counterStatvalue struct {
 }
 
 type counterUdpPkt struct {
-	Pid int32
-	Pkt [4096]uint8
+	Srcip   struct{ In6U struct{ U6Addr8 [16]uint8 } }
+	Dstip   struct{ In6U struct{ U6Addr8 [16]uint8 } }
+	SrcPort uint16
+	DstPort uint16
+	Pid     int32
+	Comm    [16]int8
+	Pkt     [4096]uint8
 }
 
 // loadCounter returns the embedded CollectionSpec for counter.
@@ -110,7 +115,8 @@ type counterMapSpecs struct {
 // counterVariableSpecs contains global variables before they are loaded into the kernel.
 //
 // It can be passed ebpf.CollectionSpec.Assign.
-type counterVariableSpecs struct{}
+type counterVariableSpecs struct {
+}
 
 // counterObjects contains all objects after they have been loaded into the kernel.
 //
@@ -150,7 +156,8 @@ func (m *counterMaps) Close() error {
 // counterVariables contains all global variables after they have been loaded into the kernel.
 //
 // It can be passed to loadCounterObjects or ebpf.CollectionSpec.LoadAndAssign.
-type counterVariables struct{}
+type counterVariables struct {
+}
 
 // counterPrograms contains all programs after they have been loaded into the kernel.
 //

--- a/main.go
+++ b/main.go
@@ -162,7 +162,7 @@ func main() {
 		log.Printf("Failed to create ringbuf reader for UDP packets: %v", err)
 	} else {
 		log.Printf("Created UDP packet ringbuf reader successfully")
-		go processUDPPackets(ctx, udpPktReader, dnsLookupMap, dnsLookupMapMutex)
+		go processUDPPackets(ctx, udpPktReader)
 		defer udpPktReader.Close()
 	}
 
@@ -181,15 +181,6 @@ func main() {
 			// Filter out entries we've already seen and enrich with DNS data
 			var newEntries []statEntry
 			for _, entry := range entries {
-				// Enrich entry with DNS hostname if available
-				if entry.Pid != 0 {
-					dnsLookupMapMutex.RLock()
-					if hostname, exists := dnsLookupMap[uint32(entry.Pid)]; exists {
-						entry.DNSQueryName = hostname
-					}
-					dnsLookupMapMutex.RUnlock()
-				}
-
 				// For --unique tracking (without timestamp)
 				uniqueKey := fmt.Sprintf("%s:%d->%s:%d:%s:%d:%s",
 					entry.SrcIP, entry.SrcPort, entry.DstIP, entry.DstPort,


### PR DESCRIPTION
Currently we try to correlate other connections with hostnames from recent dns events. This winds up error prone and can cause surprising and incorrect correlations. This removes that functionality in favor of just printing out DNS traffic we see.

Example output (note, stderr is included in this)

```
{"timestamp":"2025-10-24T21:26:24.230490674Z","srcIp":"127.0.0.1","dstIp":"127.0.0.53","srcPort":57964,"dstPort":53,"proto":"UDP","comm":"systemd-resolve","pid":1125,"dnsQueryName":"google.com","likelyService":"dns"}
2025/10/24 21:26:24 Skipping DNS packet we've already seen
2025/10/24 21:26:24 Skipping DNS packet we've already seen
2025/10/24 21:26:24 Skipping DNS packet we've already seen
{"timestamp":"2025-10-24T21:26:24.233477378Z","srcIp":"10.0.0.10","dstIp":"10.0.0.11","srcPort":53,"dstPort":32867,"proto":"UDP","comm":"systemd-resolve","pid":1125,"dnsQueryName":"google.com","likelyService":"dns"}
2025/10/24 21:26:24 Skipping DNS packet we've already seen
{"timestamp":"2025-10-24T21:26:24.233588401Z","srcIp":"10.0.0.10","dstIp":"10.0.0.11","srcPort":53,"dstPort":60109,"proto":"UDP","comm":"systemd-resolve","pid":1125,"dnsQueryName":"google.com","likelyService":"dns"}
2025/10/24 21:26:24 Skipping DNS packet we've already seen
{"timestamp":"2025-10-24T21:26:24.233684014Z","srcIp":"127.0.0.53","dstIp":"127.0.0.1","srcPort":53,"dstPort":57964,"proto":"UDP","comm":"curl","pid":2911,"dnsQueryName":"google.com","likelyService":"dns"}
2025/10/24 21:26:24 Skipping DNS packet we've already seen
{"timestamp":"2025-10-24T21:26:24.794695024Z","srcIp":"10.0.0.11","dstIp":"216.58.210.142","srcPort":8345,"dstPort":80,"proto":"TCP","likelyService":"http"}
{"timestamp":"2025-10-24T21:26:24.794748371Z","srcIp":"10.0.0.11","dstIp":"216.58.210.142","srcPort":8345,"dstPort":80,"proto":"TCP","comm":"curl","pid":2910,"likelyService":"http"}
{"timestamp":"2025-10-24T21:26:31.79433245Z","srcIp":"10.0.0.11","dstIp":"185.125.190.57","srcPort":48097,"dstPort":123,"proto":"TCP","comm":"chronyd","pid":1378,"likelyService":"ntp"}
{"timestamp":"2025-10-24T21:27:59.794383915Z","srcIp":"10.0.0.11","dstIp":"62.241.198.252","srcPort":63175,"dstPort":123,"proto":"TCP","comm":"chronyd","pid":1378,"likelyService":"ntp"}
{"timestamp":"2025-10-24T21:29:01.794549063Z","srcIp":"10.0.0.11","dstIp":"185.125.190.56","srcPort":46829,"dstPort":123,"proto":"TCP","comm":"chronyd","pid":1378,"likelyService":"ntp"}
{"timestamp":"2025-10-24T21:29:06.794216224Z","srcIp":"10.0.0.11","dstIp":"185.251.115.30","srcPort":38546,"dstPort":123,"proto":"TCP","comm":"chronyd","pid":1378,"likelyService":"ntp"}
```

and some random digs/curls from within a pod

```
{"timestamp":"2025-10-24T21:43:02.620090993Z","srcIp":"10.42.0.23","dstIp":"162.159.137.43","srcPort":3260,"dstPort":80,"proto":"TCP","sourcePod":"default/test","likelyService":"http"}
{"timestamp":"2025-10-24T21:43:02.623845209Z","srcIp":"10.42.0.23","dstIp":"162.159.137.43","srcPort":3260,"dstPort":80,"proto":"TCP","comm":"curl","pid":14002,"sourcePod":"default/test","likelyService":"http"}
{"timestamp":"2025-10-24T21:43:02.624060973Z","srcIp":"10.42.0.23","dstIp":"162.159.137.43","srcPort":3260,"dstPort":80,"proto":"TCP","comm":"pktstat","pid":13973,"sourcePod":"default/test","likelyService":"http"}
{"timestamp":"2025-10-24T21:43:46.620011471Z","srcIp":"10.0.0.11","dstIp":"185.125.190.56","srcPort":44942,"dstPort":123,"proto":"TCP","comm":"chronyd","pid":964,"likelyService":"ntp"}
{"timestamp":"2025-10-24T21:43:48.620466371Z","srcIp":"10.0.0.11","dstIp":"185.125.190.57","srcPort":12754,"dstPort":123,"proto":"TCP","comm":"chronyd","pid":964,"likelyService":"ntp"}
{"timestamp":"2025-10-24T21:43:59.403539744Z","srcIp":"8.8.8.8","dstIp":"10.42.0.23","srcPort":53,"dstPort":35503,"proto":"UDP","comm":"isc-net-0000","pid":14028,"dstPod":"default/test","dnsQueryName":"google","likelyService":"dns"}
{"timestamp":"2025-10-24T21:43:59.620189836Z","srcIp":"10.42.0.23","dstIp":"8.8.8.8","srcPort":44938,"dstPort":53,"proto":"TCP","comm":"isc-net-0000","pid":14028,"sourcePod":"default/test","likelyService":"dns"}
{"timestamp":"2025-10-24T21:44:24.914796582Z","srcIp":"10.42.0.23","dstIp":"10.42.0.13","srcPort":36925,"dstPort":53,"proto":"UDP","comm":"coredns","pid":4360,"sourcePod":"default/test","dstPod":"kube-system/coredns-7896679cc-pcjnv","dnsQueryName":"docs.replicated.com","likelyService":"dns"}
{"timestamp":"2025-10-24T21:44:24.920841363Z","srcIp":"10.0.0.10","dstIp":"10.42.0.13","srcPort":53,"dstPort":33979,"proto":"UDP","comm":"coredns","pid":4361,"dstPod":"kube-system/coredns-7896679cc-pcjnv","dnsQueryName":"docs.replicated.com","likelyService":"dns"}
{"timestamp":"2025-10-24T21:44:24.921514747Z","srcIp":"10.43.0.10","dstIp":"10.42.0.23","srcPort":53,"dstPort":36925,"proto":"UDP","comm":"isc-net-0000","pid":14038,"dstPod":"default/test","dnsQueryName":"docs.replicated.com","likelyService":"dns"}
{"timestamp":"2025-10-24T21:44:32.994362472Z","srcIp":"10.42.0.23","dstIp":"10.42.0.13","srcPort":44657,"dstPort":53,"proto":"UDP","comm":"coredns","pid":4307,"sourcePod":"default/test","dstPod":"kube-system/coredns-7896679cc-pcjnv","dnsQueryName":"docs.replicated.com.default.svc.cluster.local","likelyService":"dns"}
2025/10/24 21:44:32 Skipping DNS packet we've already seen
{"timestamp":"2025-10-24T21:44:32.994926315Z","srcIp":"10.43.0.10","dstIp":"10.42.0.23","srcPort":53,"dstPort":44657,"proto":"UDP","comm":"curl","pid":14041,"dstPod":"default/test","dnsQueryName":"docs.replicated.com.default.svc.cluster.local","likelyService":"dns"}
2025/10/24 21:44:32 Skipping DNS packet we've already seen
{"timestamp":"2025-10-24T21:44:32.99515778Z","srcIp":"10.42.0.23","dstIp":"10.42.0.13","srcPort":53446,"dstPort":53,"proto":"UDP","comm":"coredns","pid":4307,"sourcePod":"default/test","dstPod":"kube-system/coredns-7896679cc-pcjnv","dnsQueryName":"docs.replicated.com.svc.cluster.local","likelyService":"dns"}
2025/10/24 21:44:32 Skipping DNS packet we've already seen
{"timestamp":"2025-10-24T21:44:32.99566506Z","srcIp":"10.43.0.10","dstIp":"10.42.0.23","srcPort":53,"dstPort":53446,"proto":"UDP","comm":"curl","pid":14041,"dstPod":"default/test","dnsQueryName":"docs.replicated.com.svc.cluster.local","likelyService":"dns"}
2025/10/24 21:44:32 Skipping DNS packet we've already seen
{"timestamp":"2025-10-24T21:44:32.996148522Z","srcIp":"10.42.0.23","dstIp":"10.42.0.13","srcPort":36930,"dstPort":53,"proto":"UDP","comm":"coredns","pid":4307,"sourcePod":"default/test","dstPod":"kube-system/coredns-7896679cc-pcjnv","dnsQueryName":"docs.replicated.com.cluster.local","likelyService":"dns"}
2025/10/24 21:44:32 Skipping DNS packet we've already seen
{"timestamp":"2025-10-24T21:44:32.996541832Z","srcIp":"10.43.0.10","dstIp":"10.42.0.23","srcPort":53,"dstPort":36930,"proto":"UDP","comm":"curl","pid":14041,"dstPod":"default/test","dnsQueryName":"docs.replicated.com.cluster.local","likelyService":"dns"}
2025/10/24 21:44:32 Skipping DNS packet we've already seen
{"timestamp":"2025-10-24T21:44:32.997392121Z","srcIp":"10.42.0.23","dstIp":"10.42.0.13","srcPort":38353,"dstPort":53,"proto":"UDP","comm":"coredns","pid":4307,"sourcePod":"default/test","dstPod":"kube-system/coredns-7896679cc-pcjnv","dnsQueryName":"docs.replicated.com","likelyService":"dns"}
2025/10/24 21:44:32 Skipping DNS packet we've already seen
{"timestamp":"2025-10-24T21:44:32.997626533Z","srcIp":"10.43.0.10","dstIp":"10.42.0.23","srcPort":53,"dstPort":38353,"proto":"UDP","comm":"curl","pid":14041,"dstPod":"default/test","dnsQueryName":"docs.replicated.com","likelyService":"dns"}
{"timestamp":"2025-10-24T21:44:33.002200807Z","srcIp":"10.0.0.10","dstIp":"10.42.0.13","srcPort":53,"dstPort":33979,"proto":"UDP","comm":"coredns","pid":4307,"dstPod":"kube-system/coredns-7896679cc-pcjnv","dnsQueryName":"docs.replicated.com","likelyService":"dns"}
2025/10/24 21:44:33 Skipping DNS packet we've already seen
{"timestamp":"2025-10-24T21:44:33.620069138Z","srcIp":"10.42.0.23","dstIp":"162.159.138.43","srcPort":27836,"dstPort":80,"proto":"TCP","comm":"metrics-server","pid":3854,"sourcePod":"default/test","likelyService":"http"}
{"timestamp":"2025-10-24T21:44:33.625046513Z","srcIp":"10.42.0.23","dstIp":"162.159.138.43","srcPort":27836,"dstPort":80,"proto":"TCP","comm":"curl","pid":14040,"sourcePod":"default/test","likelyService":"http"}
{"timestamp":"2025-10-24T21:44:33.625121022Z","srcIp":"10.42.0.23","dstIp":"162.159.138.43","srcPort":27836,"dstPort":80,"proto":"TCP","sourcePod":"default/test","likelyService":"http"}
{"timestamp":"2025-10-24T21:44:33.625455525Z","srcIp":"10.42.0.23","dstIp":"162.159.138.43","srcPort":27836,"dstPort":80,"proto":"TCP","comm":"ksoftirqd/1","pid":18,"sourcePod":"default/test","likelyService":"http"}
```