### PR TITLE
fix: default external-only to true, filter internal dns names

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -40,7 +40,7 @@ func parseFlags() {
 	help = fs.Bool('?', "help", "display help")
 	uniqueOutput = fs.Bool('u', "unique", "if true, only show the first instance of each connection")
 	kubeconfig = fs.StringLong("kubeconfig", "", "path to kubeconfig file (if not set, dynamic kubeconfig discovery is used)")
-	externalOnly = fs.Bool('e', "external", "if true, only show traffic to external destinations")
+	externalOnly = fs.BoolDefault('e', "external", true, "if true, only show traffic to external destinations")
 	version = fs.BoolLong("version", "display program version")
 
 	var err error

--- a/output.go
+++ b/output.go
@@ -68,18 +68,9 @@ func processMap(m *ebpf.Map, sortFunc func([]statEntry)) ([]statEntry, error) {
 			continue
 		}
 
-		// Check if this IP is a DNS service
-		isDNSTraffic := false
-		for _, dnsIP := range dnsServiceIPs {
-			if dstIPStr == dnsIP || srcIPStr == dnsIP {
-				isDNSTraffic = true
-				break
-			}
-		}
-
 		// Skip if external-only is enabled and destination IP is internal
 		// But always include DNS traffic even with externalOnly flag
-		if externalOnly != nil && *externalOnly && !isDNSTraffic && !isExternalIP(dstIP) {
+		if externalOnly != nil && *externalOnly && !isExternalIP(dstIP) {
 			continue
 		}
 


### PR DESCRIPTION
Defaults external-only flag to true and adds filtering of DNS names that match special use domains when external-only is set to true.