### PR TITLE
chore: add ability to limit the number of events that are output

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -32,6 +32,7 @@ import (
 var (
 	uniqueOutput, version, help, externalOnly *bool
 	kubeconfig                                *string
+	maxEvents                                 int
 )
 
 func parseFlags() {
@@ -41,6 +42,7 @@ func parseFlags() {
 	uniqueOutput = fs.Bool('u', "unique", "if true, only show the first instance of each connection")
 	kubeconfig = fs.StringLong("kubeconfig", "", "path to kubeconfig file (if not set, dynamic kubeconfig discovery is used)")
 	externalOnly = fs.BoolDefault('e', "external", true, "if true, only show traffic to external destinations")
+	maxEventsPtr := fs.Int('m', "max-events", 10000, "max number of events to output, 0 for unlimited")
 	version = fs.BoolLong("version", "display program version")
 
 	var err error
@@ -63,4 +65,6 @@ func parseFlags() {
 
 		os.Exit(0)
 	}
+
+	maxEvents = *maxEventsPtr
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/dkorunic/pktstat-bpf
 
 go 1.24.0
 
-toolchain go1.24.1
+toolchain go1.25.4
 
 require (
 	github.com/cilium/ebpf v0.18.0


### PR DESCRIPTION
Adds a configurable max number of events to output. Defaults to 10k.

Tested this running in a vm:

```shell
[mikhailswift@b50e8e5f ~]$ ls
pktstat-bpf  test-flooding-dns-requests.sh
[mikhailswift@b50e8e5f ~]$ exit^C
[mikhailswift@b50e8e5f ~]$ ./test-flooding-dns-requests.sh
Starting DNS request flood for 60 seconds...
Press Ctrl+C to stop

Completed! Sent 11203 DNS requests in 60 seconds
Average rate: 186 requests/second
```

```shell
[mikhailswift@b50e8e5f ~]$ sudo ./pktstat-bpf > output
2025/11/21 00:05:32 No kubeconfig specified, starting auto-discovery
2025/11/21 00:05:32 Watching parent directory for kubeconfig: /root
2025/11/21 00:05:32 Watching directory for kubeconfig: /tmp
2025/11/21 00:05:32 Watching parent directory for kubeconfig: /etc
2025/11/21 00:05:32 Attaching "tcp_sendmsg" KProbe
2025/11/21 00:05:32 Attaching "tcp_cleanup_rbuf" KProbe
2025/11/21 00:05:32 Attaching "ip_send_skb" KProbe
2025/11/21 00:05:32 Attaching "ip_local_out" KProbe
2025/11/21 00:05:32 Attaching "ip_output" KProbe
2025/11/21 00:05:32 Attaching "skb_consume_udp" KProbe
2025/11/21 00:05:32 Attaching "__icmp_send" KProbe
2025/11/21 00:05:32 Attaching "icmp6_send" KProbe
2025/11/21 00:05:32 Attaching "icmp_rcv" KProbe
2025/11/21 00:05:32 Attaching "icmpv6_rcv" KProbe
2025/11/21 00:05:32 Created UDP packet ringbuf reader successfully
2025/11/21 00:06:05 Max number of events has been met, no longer outputting any events
^CReceived interrupt signal, exiting...
2025/11/21 00:14:47 Config discovery stopped
[mikhailswift@b50e8e5f ~]$ wc -l ./output
10000 ./output
```

